### PR TITLE
[th/run-in-thread] add Host.run_in_thread() helper and improve usability of FutureThread

### DIFF
--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -845,6 +845,10 @@ class LocalHost(Host):
                 assert stream is pr.stderr
                 is_stdout = False
             while True:
+                if read_all:
+                    to_read, _, _ = select.select([stream], [], [], 0)
+                    if not to_read:
+                        return
                 b = stream.readline()
                 if not b:
                     return
@@ -913,6 +917,7 @@ class LocalHost(Host):
             if pr.poll() is not None:
                 returncode = pr.returncode
                 break
+
         _readlines(pr.stdout, read_all=True)
         _readlines(pr.stderr, read_all=True)
 

--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -273,6 +273,12 @@ class Result(BaseResult[str]):
 
     CANCELLED: typing.ClassVar["Result"]
 
+    def _maybe_intern(self) -> "Result":
+        if self.cancelled and self == Result.CANCELLED:
+            assert self is not Result.CANCELLED
+            return self.CANCELLED
+        return self
+
 
 @dataclass(frozen=True)
 class BinResult(BaseResult[bytes]):
@@ -310,6 +316,11 @@ class BinResult(BaseResult[bytes]):
         )
 
     CANCELLED: typing.ClassVar["BinResult"]
+
+    def _maybe_intern(self) -> "BinResult":
+        if self.cancelled and self == BinResult.CANCELLED:
+            return self.CANCELLED
+        return self
 
 
 BinResult.CANCELLED = BinResult.new_internal(
@@ -660,8 +671,8 @@ class Host(ABC):
             sys.exit(common.FATAL_EXIT_CODE)
 
         if str_result is not None:
-            return str_result
-        return bin_result
+            return str_result._maybe_intern()
+        return bin_result._maybe_intern()
 
     @abstractmethod
     def _run(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1317,7 +1317,7 @@ def test_future_thread() -> None:
     assert thread.poll() is None
     thread.cancellable.cancel()
 
-    end_time = time.monotonic() + 1.0
+    end_time = time.monotonic() + 5.0
     while True:
         r = thread.poll()
         if r is not None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,6 +8,7 @@ import pytest
 import random
 import re
 import sys
+import time
 import typing
 
 from collections.abc import Iterable
@@ -1308,6 +1309,31 @@ def test_structparse_pop_objlist_as_dict() -> None:
 def test_future_thread() -> None:
     thread = common.FutureThread(lambda th: host.local.run("echo hi"), start=True)
     assert thread.join_and_result() == host.Result("hi\n", "", 0)
+
+    thread = common.FutureThread(
+        lambda th: host.local.run("sleep 10000", cancellable=th.cancellable),
+        start=True,
+    )
+    assert thread.poll() is None
+    thread.cancellable.cancel()
+
+    end_time = time.monotonic() + 1.0
+    while True:
+        r = thread.poll()
+        if r is not None:
+            assert (
+                r
+                == host.Result(
+                    out="",
+                    err="",
+                    returncode=-15,
+                    cancelled=True,
+                )
+                or r == host.Result.CANCELLED
+            )
+            assert r is thread.join_and_result()
+            break
+        assert time.monotonic() < end_time
 
 
 def test_path_norm() -> None:


### PR DESCRIPTION
- host: fix hanging in Host.run() during final ready
- common: add FutureThread helper methods
- host: add host.Host.run_in_thread()
- host: intern Host.run() results for CANCELLED singleton
