### PR TITLE
[th/log-file-fixes] fixes for handling of KTOOLBOX_LOGFILE

### DIFF
--- a/ktoolbox/common.py
+++ b/ktoolbox/common.py
@@ -1945,7 +1945,14 @@ def _env_get_ktoolbox_logfile_parse(
         match_str = match.group(0)
         if match_str not in substitutions:
             return match_str
-        return (substitutions[match_str])()
+
+        val = (substitutions[match_str])()
+
+        # Freeze the value that we fetched (so that multiple replacements are
+        # guaranteed to give the same result).
+        substitutions[match_str] = lambda: val
+
+        return val
 
     v = re.sub("%.", _replace, v)
 

--- a/ktoolbox/common.py
+++ b/ktoolbox/common.py
@@ -1917,7 +1917,7 @@ def _env_get_ktoolbox_logfile_parse(
 ) -> Optional[tuple[str, Optional[int], bool]]:
     if not v:
         return None
-    append = False
+    append = True
     level: Optional[int] = None
     if ":" in v:
         s_level, v = v.split(":", 1)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1620,43 +1620,49 @@ def test_env_get_ktoolbox_logfile_parse() -> None:
     rep_t = str(common._get_program_epoch())
 
     assert parse("") is None
-    assert parse("x") == ("x", None, False)
-    assert parse("::x") == (":x", None, False)
+    assert parse("x") == ("x", None, True)
+    assert parse("::x") == (":x", None, True)
     assert parse("+x") == ("x", None, True)
+    assert parse("=x") == ("x", None, False)
     assert parse(":+x") == ("x", None, True)
-    assert parse("debug:x") == ("x", logging.DEBUG, False)
+    assert parse("debug:x") == ("x", logging.DEBUG, True)
     assert parse("debug:=x") == ("x", logging.DEBUG, False)
     assert parse("DEBUG:+x") == ("x", logging.DEBUG, True)
     assert parse("DEBUG:+x%p%h") == (f"x{rep_p}{rep_h}", logging.DEBUG, True)
     assert parse("DEBUG:+x%%p%h") == (f"x%p{rep_h}", logging.DEBUG, True)
-    assert parse("invalid_level:x") == ("x", None, False)
-    assert parse("file.txt") == ("file.txt", None, False)
-    assert parse("%%") == ("%", None, False)
-    assert parse("%p") == (rep_p, None, False)
-    assert parse("%h") == (rep_h, None, False)
-    assert parse("test_%p_%h.log") == (f"test_{rep_p}_{rep_h}.log", None, False)
-    assert parse("file_%%p%%h.log") == ("file_%p%h.log", None, False)
+    assert parse("invalid_level:x") == ("x", None, True)
+    assert parse("file.txt") == ("file.txt", None, True)
+    assert parse("%%") == ("%", None, True)
+    assert parse("%p") == (rep_p, None, True)
+    assert parse("%h") == (rep_h, None, True)
+    assert parse("test_%p_%h.log") == (f"test_{rep_p}_{rep_h}.log", None, True)
+    assert parse("file_%%p%%h.log") == ("file_%p%h.log", None, True)
     assert parse("debug:+logfile.txt") == ("logfile.txt", logging.DEBUG, True)
     assert parse("info:=logfile.txt") == ("logfile.txt", logging.INFO, False)
-    assert parse("WARNING:logfile.txt") == ("logfile.txt", logging.WARNING, False)
+    assert parse("WARNING:logfile.txt") == ("logfile.txt", logging.WARNING, True)
     assert parse("debug:+logfile.txt") == ("logfile.txt", logging.DEBUG, True)
     assert parse("info:+log_%p_%h.log") == (
         f"log_{rep_p}_{rep_h}.log",
         logging.INFO,
         True,
     )
-    assert parse(":logfile.txt") == ("logfile.txt", None, False)
-    assert parse("debug:foo:bar") == ("foo:bar", logging.DEBUG, False)
+    assert parse(":logfile.txt") == ("logfile.txt", None, True)
+    assert parse("debug:foo:bar") == ("foo:bar", logging.DEBUG, True)
     assert parse("DeBuG:+logfile.txt") == ("logfile.txt", logging.DEBUG, True)
     assert parse("InFo:+logfile.txt") == ("logfile.txt", logging.INFO, True)
-    assert parse("%%p%%h:.log") == (".log", None, False)
-    assert parse("debug:foo:bar") == ("foo:bar", logging.DEBUG, False)
+    assert parse("%%p%%h:.log") == (".log", None, True)
+    assert parse("debug:foo:bar") == ("foo:bar", logging.DEBUG, True)
     assert parse("debug:+file_%%p%%h:.log") == ("file_%p%h:.log", logging.DEBUG, True)
     assert parse("debug:") is None
-    assert parse("file_%%p%h.log") == (f"file_%p{rep_h}.log", None, False)
-    assert parse("debug:logfile.txt") == ("logfile.txt", logging.DEBUG, False)
+    assert parse("file_%%p%h.log") == (f"file_%p{rep_h}.log", None, True)
+    assert parse("file_%%p%h%p%h%p.log") == (
+        f"file_%p{rep_h}{rep_p}{rep_h}{rep_p}.log",
+        None,
+        True,
+    )
+    assert parse("debug:logfile.txt") == ("logfile.txt", logging.DEBUG, True)
     assert parse("debug:logfile-%t.txt") == (
         f"logfile-{rep_t}.txt",
         logging.DEBUG,
-        False,
+        True,
     )


### PR DESCRIPTION
- common: ensure pattern replacement for KTOOLBOX_LOGFILE uses same values
- common: default to appending files for KTOOLBOX_LOGFILE
